### PR TITLE
Enable mixed call stacks when debuggee loads a mono-2.0* dynamic libr…

### DIFF
--- a/UnityMixedCallstack.vsdconfigxml
+++ b/UnityMixedCallstack.vsdconfigxml
@@ -12,6 +12,7 @@
           <NoFilter/>
           <Interface Name="IDkmCallStackFilter"/>
           <Interface Name="IDkmLoadCompleteNotification"/>
+          <Interface Name="IDkmModuleInstanceLoadNotification"/>
         </InterfaceGroup>
       </Implements>
     </Class>

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="UnityMixedCallstack.mderoy.1bc395e8-c1ea-4a2d-8a37-19e7f0c302b9" Version="2.1" Language="en-US" Publisher="Jb Evain, Michael DeRoy, Jonathan Chambers" />
+    <Identity Id="UnityMixedCallstack.mderoy.1bc395e8-c1ea-4a2d-8a37-19e7f0c302b9" Version="2.2" Language="en-US" Publisher="Jb Evain, Michael DeRoy, Jonathan Chambers" />
     <DisplayName>Unity Mixed Callstack</DisplayName>
     <Description xml:space="preserve">Visual Studio native debugger extension to help debug native applications using Mono. Originally developed by Jb Evain, Updated for Unity by Michael DeRoy and Jonathan Chambers</Description>
   </Metadata>


### PR DESCRIPTION
…ary into the process. We still only process if a file exists on disk with the same process id. Also, enable mixed call stacks for non-main threads.