### PR TITLE
Fix crash when minidump contains mono-2.0 dll (aka minidumps of unity games)

### DIFF
--- a/UnityMixedCallstackFilter.cs
+++ b/UnityMixedCallstackFilter.cs
@@ -181,7 +181,7 @@ namespace UnityMixedCallstack
 
         public void OnModuleInstanceLoad(DkmModuleInstance moduleInstance, DkmWorkList workList, DkmEventDescriptorS eventDescriptor)
         {
-            if (moduleInstance.Name.Contains("mono-2.0"))
+            if (moduleInstance.Name.Contains("mono-2.0") && moduleInstance.MinidumpInfoPart == null)
                 _enabled = true;
         }
     }

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="UnityMixedCallstack.mderoy.1bc395e8-c1ea-4a2d-8a37-19e7f0c302b9" Version="2.3" Language="en-US" Publisher="Jb Evain, Michael DeRoy, Jonathan Chambers" />
+    <Identity Id="UnityMixedCallstack.mderoy.1bc395e8-c1ea-4a2d-8a37-19e7f0c302b9" Version="2.4" Language="en-US" Publisher="Jb Evain, Michael DeRoy, Jonathan Chambers" />
     <DisplayName>Unity Mixed Callstack</DisplayName>
     <Description xml:space="preserve">Visual Studio native debugger extension to help debug native applications using Mono. Originally developed by Jb Evain, Updated for Unity by Michael DeRoy and Jonathan Chambers</Description>
   </Metadata>


### PR DESCRIPTION
Check for the minidumpinfo part before enabling the plugin. This will prevent crashes when debugging a minidump that contains mono-2.0-bdwgc.dll