### PR TITLE
Fix parsing of version field when decimal separator is not "."

### DIFF
--- a/UnityMixedCallstackFilter.cs
+++ b/UnityMixedCallstackFilter.cs
@@ -119,7 +119,8 @@ namespace UnityMixedCallstack
                     if (tokens.Length != 2)
                         throw new Exception("Failed reading input file " + fileName + ": Incorrect format");
 
-                    var version = double.Parse(tokens[1]);
+                    if (!double.TryParse(tokens[1], NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var version))
+                        throw new Exception("Failed reading input file " + fileName + ": Incorrect version format");
 
                     if(version > 1.0)
                         throw new Exception("Failed reading input file " + fileName + ": A newer version of UnityMixedCallstacks plugin is required to read this file");


### PR DESCRIPTION
This should fix an issue where pmip file parsing fails if your system is configured with a decimal separator that is not `.`. On my system I had `,` set as the decimal separator (default for danish region setting) and managed addresses were not translated but as soon as I set it to `.` it started working.

This is mostly a speculative fix since I'm not actually sure how to build/package the extension in order to load it into VS so I haven't tested it beyond trying to parse some different version numbers with different decimal separators configured.