### PR TITLE
Add support for Visual Studio 2022.

### DIFF
--- a/UnityMixedCallstack.csproj
+++ b/UnityMixedCallstack.csproj
@@ -5,8 +5,8 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <!-- <VSSDK140Install Condition="'$(VSSDK140Install)' == ''">$(MSBuildProgramFiles32)\Microsoft Visual Studio 14.0\VSSDK\</VSSDK140Install> -->
-    <VSSdkPath Condition="'$(VisualStudioVersion.Contains(`17`))'">$(ProgramFiles)\Microsoft Visual Studio\2022\VSSDK\</VSSdkPath>
-    <VSSdkPath Condition="'$(VisualStudioVersion.Contains(`16`))'">$(MSBuildProgramFiles32)\Microsoft Visual Studio\2019\VSSDK\</VSSdkPath>
+    <VSSdkPath Condition="'$(VisualStudioVersion.Contains(`17`))'">$(ProgramFiles)\Microsoft Visual Studio\2022\Professional\VSSDK\</VSSdkPath>
+    <VSSdkPath Condition="'$(VisualStudioVersion.Contains(`16`))'">$(MSBuildProgramFiles32)\Microsoft Visual Studio\2019\Professional\VSSDK\</VSSdkPath>
     <VsixType>v3</VsixType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/UnityMixedCallstack.csproj
+++ b/UnityMixedCallstack.csproj
@@ -1,14 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <!-- <VSSDK140Install Condition="'$(VSSDK140Install)' == ''">$(MSBuildProgramFiles32)\Microsoft Visual Studio 14.0\VSSDK\</VSSDK140Install> -->
-    <VSSDK170Install Condition="'$(VSSDK170Install)' == ''">$(MSBuildProgramFiles32)\Microsoft Visual Studio\2019\Professional\VSSDK\</VSSDK170Install>
+    <VSSDK180Install Condition="'$(VSSDK180Install)' == ''">$(PROGRAMFILES)\Microsoft Visual Studio\2022\VSSDK\</VSSDK180Install>
     <VsixType>v3</VsixType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -20,11 +21,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UnityMixedCallStack</RootNamespace>
     <AssemblyName>UnityMixedCallStack</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <!--Root directory to Concord SDK install; includes the trailing backslash '\'.-->
-    <ConcordSDKDir>$(VSSDK170Install)VisualStudioIntegration\</ConcordSDKDir>
+    <ConcordSDKDir>$(VSSDK180Install)VisualStudioIntegration\</ConcordSDKDir>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -54,8 +55,6 @@
     <StartArguments>/rootsuffix Exp</StartArguments>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.VisualStudio.Debugger.Engine">
@@ -79,10 +78,11 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Sdk.BuildTasks.14.0">
-      <Version>14.9.23</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
+    <PackageReference Include="Microsoft.VisualStudio.SDK">
+      <Version>17.0.31902.203</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Debugger.Engine">
+      <Version>17.0.1110801</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/UnityMixedCallstack.csproj
+++ b/UnityMixedCallstack.csproj
@@ -1,11 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <!-- <VSSDK140Install Condition="'$(VSSDK140Install)' == ''">$(MSBuildProgramFiles32)\Microsoft Visual Studio 14.0\VSSDK\</VSSDK140Install> -->
-    <VSSDK180Install Condition="'$(VSSDK180Install)' == ''">$(PROGRAMFILES)\Microsoft Visual Studio\2022\VSSDK\</VSSDK180Install>
+    <VSSdkPath Condition="'$(VisualStudioVersion.Contains(`17`))'">$(ProgramFiles)\Microsoft Visual Studio\2022\VSSDK\</VSSdkPath>
+    <VSSdkPath Condition="'$(VisualStudioVersion.Contains(`16`))'">$(MSBuildProgramFiles32)\Microsoft Visual Studio\2019\VSSDK\</VSSdkPath>
     <VsixType>v3</VsixType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
@@ -25,7 +26,7 @@
     <FileAlignment>512</FileAlignment>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <!--Root directory to Concord SDK install; includes the trailing backslash '\'.-->
-    <ConcordSDKDir>$(VSSDK180Install)VisualStudioIntegration\</ConcordSDKDir>
+    <ConcordSDKDir>$(VSSdkPath)VisualStudioIntegration\</ConcordSDKDir>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -54,12 +55,41 @@
     <StartWorkingDirectory>$(DevEnvDir)</StartWorkingDirectory>
     <StartArguments>/rootsuffix Exp</StartArguments>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <VsVersion Condition="'$(VisualStudioVersion.Contains(`17`))'">VS2022</VsVersion>
+    <VsVersion Condition="'$(VisualStudioVersion.Contains(`16`))'">VS2019</VsVersion>
+    <OutputPath>bin\$(VsVersion)\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(VsVersion)\$(Configuration)\</IntermediateOutputPath>    
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VsVersion)' == 'VS2022'">
+      <PropertyGroup>
+        <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+      </PropertyGroup>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203" />
+        <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5232" />
+        <PackageReference Include="Microsoft.VisualStudio.Debugger.Engine" Version="17.0.1110801" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+      </PropertyGroup>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.VisualStudio.SDK" Version="15.0.1" />
+        <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.9.3039" />
+        <PackageReference Include="Microsoft.VisualStudio.Debugger.Engine" Version="15.9.28307" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.VisualStudio.Debugger.Engine">
-      <HintPath>$(ConcordSDKDir)Reference Assemblies\Microsoft.VisualStudio.Debugger.Engine.dll</HintPath>
-      <Private>False</Private>
+        <HintPath>$(ConcordSDKDir)Reference Assemblies\Microsoft.VisualStudio.Debugger.Engine.dll</HintPath>
+        <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -74,17 +104,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="source.extension.vsixmanifest">
-      <SubType>Designer</SubType>
+        <SubType>Designer</SubType>
     </None>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>17.0.31902.203</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Debugger.Engine">
-      <Version>17.0.1110801</Version>
-    </PackageReference>
-  </ItemGroup>
+  </ItemGroup>    
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(ConcordSDKDir)Tools\bin\Microsoft.VSSDK.Debugger.VSDConfigTool.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -6,15 +6,17 @@
     <Description xml:space="preserve">Visual Studio native debugger extension to help debug native applications using Mono. Originally developed by Jb Evain, Updated for Unity by Michael DeRoy and Jonathan Chambers</Description>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0, 17.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0]">
+        <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
   </Installation>
   <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.8" />
   </Dependencies>
   <Assets>
     <Asset Type="DebuggerEngineExtension" Path="UnityMixedCallstack.vsdconfig"/>
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.25904.2,)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
 </PackageManifest>

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -6,17 +6,21 @@
     <Description xml:space="preserve">Visual Studio native debugger extension to help debug native applications using Mono. Originally developed by Jb Evain, Updated for Unity by Michael DeRoy and Jonathan Chambers</Description>
   </Metadata>
   <Installation>
+    <!-- Enable/Disable as needed. For now enabled for VS2022-->
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0]">
         <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
+    <!--
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,)" />
+    -->
   </Installation>
   <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.8" />
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />
   </Dependencies>
   <Assets>
     <Asset Type="DebuggerEngineExtension" Path="UnityMixedCallstack.vsdconfig"/>
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.25904.2,)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Added initial support for Visual Studio 2022.
Tested with recent trunk with both 2019 and 2022. 

2 things that may need cleanup :
1. Getting Visual Studio path seems a bit tricky. Used my local path for now.
2. VSIX Manifest needs comment/uncomment depending on version building for. 